### PR TITLE
Correctly format filename based on vault catalog output

### DIFF
--- a/src/main/java/nl/knaw/dans/vaultingest/client/AbstractDepositValidator.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/client/AbstractDepositValidator.java
@@ -65,10 +65,6 @@ public abstract class AbstractDepositValidator implements DepositValidator {
                 }
             }
         }
-        catch (ProcessingException e) {
-            log.error("Unable to connect to validator service on URL {}", serviceUri);
-            throw e;
-        }
         catch (IOException e) {
             log.error("Unable to create multipart form data object", e);
         }

--- a/src/main/java/nl/knaw/dans/vaultingest/client/AbstractDepositValidator.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/client/AbstractDepositValidator.java
@@ -22,10 +22,12 @@ import nl.knaw.dans.vaultingest.core.validator.DepositValidator;
 import nl.knaw.dans.vaultingest.core.validator.InvalidDepositException;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -62,6 +64,10 @@ public abstract class AbstractDepositValidator implements DepositValidator {
                     throw formatValidationError(response.readEntity(ValidateOkDto.class));
                 }
             }
+        }
+        catch (ProcessingException e) {
+            log.error("Unable to connect to validator service on URL {}", serviceUri);
+            throw e;
         }
         catch (IOException e) {
             log.error("Unable to create multipart form data object", e);

--- a/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
@@ -99,6 +99,12 @@ public class DepositToBagProcess {
             deposit.setNbn(idMinter.mintUrnNbn());
         }
 
+        var registeredDeposit = vaultCatalogService.registerDeposit(deposit);
+
+        if (registeredDeposit != null) {
+            deposit.setObjectVersion(registeredDeposit.getObjectVersion());
+        }
+
         // send rda bag to vault
         try {
             try (var writer = bagOutputWriterFactory.createBagOutputWriter(deposit)) {
@@ -111,7 +117,6 @@ public class DepositToBagProcess {
             throw new IllegalStateException("Error writing bag: " + e.getMessage(), e);
         }
 
-        vaultCatalogService.registerDeposit(deposit);
     }
 
     void handleFailedDeposit(Path path, Outbox outbox, Deposit.State state, Throwable error) {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
@@ -100,10 +100,7 @@ public class DepositToBagProcess {
         }
 
         var registeredDeposit = vaultCatalogService.registerDeposit(deposit);
-
-        if (registeredDeposit != null) {
-            deposit.setObjectVersion(registeredDeposit.getObjectVersion());
-        }
+        deposit.setObjectVersion(registeredDeposit.getObjectVersion());
 
         // send rda bag to vault
         try {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/deposit/Deposit.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/deposit/Deposit.java
@@ -41,6 +41,7 @@ public class Deposit {
     private final DepositBag bag;
     private final boolean migration;
     private String nbn;
+    private Long objectVersion;
 
     public Path getPath() {
         return path;
@@ -147,6 +148,14 @@ public class Deposit {
 
     public InputStream inputStreamForMetadataFile(Path path) {
         return bag.inputStreamForMetadataFile(path);
+    }
+
+    public Long getObjectVersion() {
+        return objectVersion;
+    }
+
+    public void setObjectVersion(Long objectVersion) {
+        this.objectVersion = objectVersion;
     }
 
     public enum State {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/rdabag/output/ZipBagOutputWriterFactory.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/rdabag/output/ZipBagOutputWriterFactory.java
@@ -38,7 +38,7 @@ public class ZipBagOutputWriterFactory implements BagOutputWriterFactory {
         Objects.requireNonNull(bagId);
         Objects.requireNonNull(objectVersion);
 
-        // strip anything before the colon (if present), and also the colon itself
+        // strip anything before all colons (if present), and also the colon itself
         bagId = bagId.toLowerCase().replaceAll(".*:", "");
 
         return String.format("vaas-%s-v%s.zip", bagId, objectVersion);

--- a/src/main/java/nl/knaw/dans/vaultingest/core/rdabag/output/ZipBagOutputWriterFactory.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/rdabag/output/ZipBagOutputWriterFactory.java
@@ -30,15 +30,17 @@ public class ZipBagOutputWriterFactory implements BagOutputWriterFactory {
 
     @Override
     public BagOutputWriter createBagOutputWriter(Deposit deposit) throws IOException {
-        var doi = Objects.requireNonNull(deposit.getDoi(), "Deposit DOI is null");
-        // TODO version should be coming from the deposit, or should it?
-        // this is to be determined by Jan and Linda
-        var output = outputDir.resolve(outputFilename(doi, "1.0"));
+        var output = outputDir.resolve(outputFilename(deposit.getBagId(), deposit.getObjectVersion()));
         return new ZipBagOutputWriter(output);
     }
 
-    private Path outputFilename(String doi, String version) {
-        doi = doi.replaceAll("[^a-zA-Z0-9]", "-");
-        return Path.of(String.format("%s-v%s.zip", doi, version).toLowerCase());
+    String outputFilename(String bagId, Long objectVersion) {
+        Objects.requireNonNull(bagId);
+        Objects.requireNonNull(objectVersion);
+
+        // strip anything before the colon (if present), and also the colon itself
+        bagId = bagId.toLowerCase().replaceAll(".*:", "");
+
+        return String.format("vaas-%s-v%s.zip", bagId, objectVersion);
     }
 }

--- a/src/main/java/nl/knaw/dans/vaultingest/core/vaultcatalog/VaultCatalogDeposit.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/vaultcatalog/VaultCatalogDeposit.java
@@ -21,6 +21,8 @@ import lombok.Value;
 @Value
 @Builder
 public class VaultCatalogDeposit {
+    String bagId;
+    Long objectVersion;
     String dataSupplier;
     String nbn;
 }

--- a/src/main/java/nl/knaw/dans/vaultingest/core/vaultcatalog/VaultCatalogRepository.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/vaultcatalog/VaultCatalogRepository.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 public interface VaultCatalogRepository {
 
-    void registerDeposit(Deposit deposit) throws IOException;
+    VaultCatalogDeposit registerDeposit(Deposit deposit) throws IOException;
 
     Optional<VaultCatalogDeposit> findDeposit(String swordToken) throws IOException;
 }

--- a/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
@@ -32,7 +32,6 @@ import nl.knaw.dans.vaultingest.core.vaultcatalog.VaultCatalogRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -215,7 +214,10 @@ class DepositToBagProcessTest {
             () -> rdaBagWriter,
             d -> new NullBagOutputWriter(),
             vaultCatalogService,
-            depositManager, depositValidator, new IdMinter());
+            depositManager,
+            depositValidator,
+            new IdMinter()
+        );
 
         depositToBagProcess.processDeposit(deposit);
 

--- a/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
@@ -28,6 +28,7 @@ import nl.knaw.dans.vaultingest.core.utilities.NullBagOutputWriter;
 import nl.knaw.dans.vaultingest.core.utilities.TestDepositManager;
 import nl.knaw.dans.vaultingest.core.validator.DepositValidator;
 import nl.knaw.dans.vaultingest.core.validator.InvalidDepositException;
+import nl.knaw.dans.vaultingest.core.vaultcatalog.VaultCatalogDeposit;
 import nl.knaw.dans.vaultingest.core.vaultcatalog.VaultCatalogRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -46,6 +47,9 @@ class DepositToBagProcessTest {
         var output = new InMemoryOutputWriter();
         var vaultCatalogService = Mockito.mock(VaultCatalogRepository.class);
         var depositValidator = Mockito.mock(DepositValidator.class);
+
+        Mockito.when(vaultCatalogService.registerDeposit(Mockito.any()))
+            .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
 
         var deposit = getBasicDeposit();
         var depositManager = TestDepositManager.ofDeposit(deposit);
@@ -79,6 +83,9 @@ class DepositToBagProcessTest {
         var vaultCatalogService = Mockito.mock(VaultCatalogRepository.class);
         var depositValidator = Mockito.mock(DepositValidator.class);
 
+        Mockito.when(vaultCatalogService.registerDeposit(Mockito.any()))
+            .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
+
         var depositManager = Mockito.spy(TestDepositManager.ofDeposit(null));
         Mockito.doThrow(new RuntimeException("error")).when(depositManager).loadDeposit(Mockito.any());
 
@@ -106,6 +113,9 @@ class DepositToBagProcessTest {
         var output = new InMemoryOutputWriter();
         var vaultCatalogService = Mockito.mock(VaultCatalogRepository.class);
         var depositValidator = Mockito.mock(DepositValidator.class);
+
+        Mockito.when(vaultCatalogService.registerDeposit(Mockito.any()))
+            .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
 
         Mockito.doThrow(new InvalidDepositException("Invalid deposit!"))
             .when(depositValidator).validate(Mockito.any());
@@ -136,6 +146,9 @@ class DepositToBagProcessTest {
         var output = new InMemoryOutputWriter();
         var vaultCatalogService = Mockito.mock(VaultCatalogRepository.class);
         var depositValidator = Mockito.mock(DepositValidator.class);
+
+        Mockito.when(vaultCatalogService.registerDeposit(Mockito.any()))
+            .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
 
         Mockito.when(vaultCatalogService.findDeposit(Mockito.any()))
             .thenReturn(Optional.empty());
@@ -175,6 +188,9 @@ class DepositToBagProcessTest {
             new IdMinter()
         );
 
+        Mockito.when(vaultCatalogService.registerDeposit(Mockito.any()))
+            .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
+
         var deposit = getBasicDeposit();
         depositToBagProcess.processDeposit(deposit);
 
@@ -210,6 +226,9 @@ class DepositToBagProcessTest {
         var depositManager = Mockito.mock(DepositManager.class);
         var depositValidator = Mockito.mock(DepositValidator.class);
 
+        Mockito.when(vaultCatalogService.registerDeposit(Mockito.any()))
+            .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
+
         var depositToBagProcess = new DepositToBagProcess(
             () -> rdaBagWriter,
             d -> new NullBagOutputWriter(),
@@ -229,6 +248,9 @@ class DepositToBagProcessTest {
         var deposit = getBasicDepositAsUpdate();
         var rdaBagWriter = getWriter();
         var vaultCatalogService = Mockito.mock(VaultCatalogRepository.class);
+
+        Mockito.when(vaultCatalogService.registerDeposit(Mockito.any()))
+            .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
 
         Mockito.doReturn(Optional.empty())
             .when(vaultCatalogService).findDeposit(Mockito.any());

--- a/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/output/ZipBagOutputWriterFactoryTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/output/ZipBagOutputWriterFactoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.vaultingest.core.rdabag.output;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ZipBagOutputWriterFactoryTest {
+
+    @Test
+    void outputFilename() {
+        var bagId = "A129CD20-01F7-49E2-B6A1-B9CECF625471";
+        var objectVersion = 15L;
+
+        var result = new ZipBagOutputWriterFactory(null).outputFilename(bagId, objectVersion);
+
+        assertThat(result).isEqualTo("vaas-a129cd20-01f7-49e2-b6a1-b9cecf625471-v15.zip");
+    }
+
+    @Test
+    void outputFilename_should_strip_urn_uuid_prefix() {
+        var bagId = "urn:uuid:A129CD20-01F7-49E2-B6A1-B9CECF625471";
+        var objectVersion = 15L;
+
+        var result = new ZipBagOutputWriterFactory(null).outputFilename(bagId, objectVersion);
+
+        assertThat(result).isEqualTo("vaas-a129cd20-01f7-49e2-b6a1-b9cecf625471-v15.zip");
+    }
+}


### PR DESCRIPTION
Fixes DD-1376

# Description of changes

Outputs a correct filename unique for the vault ingest flow, formatted as:

vaas-{uuid}-v{vault catalog object version}.zip


# How to test


# Related PRs
(Add links)
* https://github.com/DANS-KNAW/dd-transfer-to-vault/pull/35

# Notify
@DANS-KNAW/dataversedans
