### PR TITLE
DD-1356: map depositorId to dataSupplier

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -6,8 +6,8 @@ Set-up
 ------
 This project can be used in combination with  [dans-dev-tools]{:target=_blank}. 
 Before you can start it as a service some dependencies must first be started.
-One depency is [dd-validate-dans-bag].
-For the other dependency you have the choice between a local service [dd-vault-catalog] and a Virtual Machine (VM) `dev_transfer`.
+One depency is [dd-validate-dans-bag]{:target=_blank}.
+For the other dependency you have the choice between a local service [dd-vault-catalog]{:target=_blank} and a Virtual Machine (VM) `dev_transfer`.
 The local variant requires a local database. 
 For the VM you need access to the project [dd-dtap]{:target=_blank},
 
@@ -87,9 +87,6 @@ start-service.sh
     * The `bag-name` should match the copied bag.
     * The `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
     * The `<UUID>` should match the directory name
-* When using the deposit on a VM, create it at `dd-dtap/shared/<UUID>`, on the VM
-
-      cd /vagrant/shared/<UUID> ; chgrp -R deposits . ; chown -R dd-vault-ingest-flow .
 * To test updates you will need different UUIDs for each `example-bags/valid/revision*`
   and move them in proper order to the inbox, one by one after the previous completed.
 
@@ -99,9 +96,6 @@ To start an ingest locally, move (not copy, otherwise the processing might start
 a deposit into one of the inboxes configured in:
 
     dd-vault-ingest-flow/etc/config.yml
-
-To start an ingest on the VM, move it to `/var/opt/dans.knaw.nl/tmp/auto-ingest/inbox`
-as configured in `/etc/opt/dans.knaw.nl/dd-vault-ingest-flow/config.yml` 
 
 You can examine details of the result on the VM in `/var/opt/dans.knaw.nl/tmp/ocfl-tar/inbox`
 and the database: 
@@ -115,3 +109,11 @@ and the database:
 To examine the local database run `start-hsqldb-client.sh`
 and connect with the `database.url` specified in `dd-vault-catalog/etc/config.yml`,
 the zip files can be found in `dd-vault-ingest-flow/data/rda-bags`.
+
+### Test after deploy
+
+The catalog results can be found on the VM `dev_transfer` unless you opted for the local catalog service,
+the service under test (`dd-vault-ingest-flow`) should be deployed on `dev_vaas`.
+
+Move the deposit via `/vagrant/shared` (and `chmod -R 777 <UUID>`) to `/var/opt/dans.knaw.nl/tmp/auto-ingest/inbox`
+as configured in `/etc/opt/dans.knaw.nl/dd-vault-ingest-flow/config.yml`.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -10,12 +10,17 @@ For one dependency you have the choice between a Virtual Machine (VM) `dev_trans
 and a local service `dd-vault-catalog`. For the VM you need access to the project [dd-dtap]{:target=_blank},
 the local service requires a local database.
 
+[dans-dev-tools]: https://github.com/DANS-KNAW/dans-dev-tools#readme
+[dd-dtap]: https://github.com/DANS-KNAW/dd-dtap#readme
+[dd-validate-dans-bag]: https://github.com/DANS-KNAW/dd-validate-dans-bag#readme
+[dd-vault-catalog]: https://github.com/DANS-KNAW/dd-vault-catalog#readme
+
 ### Initialize development environment
 
 This is only necessary once per project. If you execute this any existing configuration and data will be reset.
 
-Open separate terminal tabs for `dd-vault-ingest-flow` and for its dependency `dd-validate-dans-bag`
-and optionally `dd-vault-catalog`. In each tab run:
+Open separate terminal tabs for `dd-vault-ingest-flow`, its dependency [dd-validate-dans-bag]
+and the optional dependency [dd-vault-catalog]. In each tab run:
 
 ```commandline
 start-env.sh
@@ -25,9 +30,9 @@ The service `dd-validate-dans-bag` needs different configurations for `dd-vault-
 So you will have to update the generated `dd-validate-dans-bag/etc/config.yml`,
 perhaps keep copies of the files or comment lines to switch between both situations.
 
-* remove one level from `../../` from the schema locations.
-* dataverse: null
-* vaultCatalog.baseUrl: https://dev.transfer.dans-data.nl/vault-catalog
+* remove one level from `../../` in the schema locations.
+* `dataverse: null`
+* `vaultCatalog.baseUrl: https://dev.transfer.dans-data.nl/vault-catalog`
 
 You will also have to adjust `dd-vault-ingest-flow/etc/config.yml`:
 
@@ -61,22 +66,22 @@ start-service.sh
 * Create a directory with a `<UUID>` as name, for example `b8f7f836-013a-4e32-9070-2efcfab3316b`.
 * Copy a valid bag into that directory, for example:
 
-      dd-dans-sword2-examples/src/main/resources/example-bags/valid/default-open
+        dd-dans-sword2-examples/src/main/resources/example-bags/valid/default-open
 
   Note that `all_mappings` has an invalid prefix for `Has-Organizational-Identifier` in `bag-info.txt`,
   other bags should be valid.
 
-* Create a file in the same directory named `deposit.properties`, an example for the content
+  * Create a file in the same directory named `deposit.properties`, an example for the content
 
-      bag-store.bag-id = b8f7f836-013a-4e32-9070-2efcfab3316b
-      dataverse.bag-id = urn:uuid:b8f7f836-013a-4e32-9070-2efcfab3316b
-      creation.timestamp = 2023-08-16T17:40:41.390209+02:00
-      deposit.origin = SWORD2
-      depositor.userId = user001
-      bag-store.bag-name = default-open
-      dataverse.sword-token = sword:b8f7f836-013a-4e32-9070-2efcfab3316b
+        bag-store.bag-id = b8f7f836-013a-4e32-9070-2efcfab3316b
+        dataverse.bag-id = urn:uuid:b8f7f836-013a-4e32-9070-2efcfab3316b
+        creation.timestamp = 2023-08-16T17:40:41.390209+02:00
+        deposit.origin = SWORD2
+        depositor.userId = user001
+        bag-store.bag-name = default-open
+        dataverse.sword-token = sword:b8f7f836-013a-4e32-9070-2efcfab3316b
 
-  Note that the `bag-name` should match the copied bag and the `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
+    Note that the `bag-name` should match the copied bag and the `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
 
 ## Start an ingest
 
@@ -90,5 +95,3 @@ and the database:
 
     sudo su postgres
     psql dd_vault_catalog
-
-[dans-dev-tools]: https://github.com/DANS-KNAW/dans-dev-tools#dans-dev-tools

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -88,6 +88,8 @@ start-service.sh
     * The `<UUID>` should match the directory name
 * To test updates you will need different UUIDs for each `example-bags/valid/*`
   and move them in proper order to the inbox, one by one after the previous completed.
+  Note that the `revision02` and `revision03` bags lack a `Is-Version-Of: <UUID>` in `bag-info.txt`.
+  Adding this property requires an update of the `tagmanifest-sha1.txt`.
 
 ## Start an ingest
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -4,14 +4,18 @@ This page contains information for developers about how to contribute to this pr
 
 Set-up
 ------
-This project can be used in combination with  [dans-dev-tools]{:target=_blank}. Before you can start it as a service
-some dependencies must first be started:
+This project can be used in combination with  [dans-dev-tools]{:target=_blank}. 
+Before you can start it as a service some dependencies must first be started.
+For one dependency you have the choice between a Virtual Machine (VM) `dev_transfer`
+and a local service `dd-vault-catalog`. For the VM you need access to the project [dd-dtap]{:target=_blank},
+the local service requires a local database.
 
 ### Initialize development environment
 
 This is only necessary once per project. If you execute this any existing configuration and data will be reset.
 
-Open a separate terminal tab for `dd-vault-ingest-flow` and one for its dependency `dd-validate-dans-bag` and in each one run:
+Open separate terminal tabs for `dd-vault-ingest-flow` and for its dependency `dd-validate-dans-bag`
+and optionally `dd-vault-catalog`. In each tab run:
 
 ```commandline
 start-env.sh
@@ -29,24 +33,24 @@ You will also have to adjust `dd-vault-ingest-flow/etc/config.yml`:
 
 * vaultCatalog.url: https://dev.transfer.dans-data.nl
 
-Both URLs in the above configuration examples assume you use the virtual machine (VM) `dev_transfer` and not additional local services and databases.
-Keep the URLs as generated when you don't use a VM.
+Both URLs in the above configuration examples assume you use the VM `dev_transfer`, 
+if not, keep the URLs as generated from `src/test/resources/debug-etc`.
 
 ### Start services
 
-When you are granted access to the project `dd-dtap` you can start the VM configured above.
+To start the VM run in the root of `dd-dtap`:
 
 ```commandline
 start-preprovisioned-box.py -s dev_transfer
 ```
 
-Without the VM you will need a local database for the service `dd-vault-catalog`, run in a separate terminal:
+Without the VM you will need a local database for the service `dd-vault-catalog`, run in a separate terminal tab:
 
 ```commandline
 start-hsqldb-server.sh
 ```
 
-Open new terminals for the services `dd-vault-ingest-flow`, `dd-validate-dans-bag`, optionally (without a VM) `dd-vault-catalog` and run:
+Open terminal tabs for the services `dd-vault-ingest-flow`, `dd-validate-dans-bag`, optionally `dd-vault-catalog` and run:
 
 ```commandline
 start-service.sh

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,0 +1,90 @@
+Development
+===========
+This page contains information for developers about how to contribute to this project.
+
+Set-up
+------
+This project can be used in combination with  [dans-dev-tools]{:target=_blank}. Before you can start it as a service
+some dependencies must first be started:
+
+### Initialize development environment
+
+This is only necessary once per project. If you execute this any existing configuration and data will be reset.
+
+Open a separate terminal tab for `dd-vault-ingest-flow` and one for its dependency `dd-validate-dans-bag` and in each one run:
+
+```commandline
+start-env.sh
+```
+
+The service `dd-validate-dans-bag` needs different configurations for `dd-vault-ingest-flow` and other services. 
+So you will have to update the generated `dd-validate-dans-bag/etc/config.yml`,
+perhaps keep copies of the files or comment lines to switch between both situations.
+
+* remove one level from `../../` from the schema locations.
+* dataverse: null
+* vaultCatalog.baseUrl: https://dev.transfer.dans-data.nl/vault-catalog
+
+You will also have to adjust `dd-vault-ingest-flow/etc/config.yml`:
+
+* vaultCatalog.url: https://dev.transfer.dans-data.nl
+
+Both URLs in the above configuration examples assume you use the virtual machine (VM) `dev_transfer` and not additional local services and databases.
+Keep the URLs as generated when you don't use a VM.
+
+### Start services
+
+When you are granted access to the project `dd-dtap` you can start the VM configured above.
+
+```commandline
+start-preprovisioned-box.py -s dev_transfer
+```
+
+Without the VM you will need a local database for the service `dd-vault-catalog`, run in a separate terminal:
+
+```commandline
+start-hsqldb-server.sh
+```
+
+Open new terminals for the services `dd-vault-ingest-flow`, `dd-validate-dans-bag`, optionally (without a VM) `dd-vault-catalog` and run:
+
+```commandline
+start-service.sh
+```
+
+### Create a deposit
+
+* Create a directory with a `<UUID>` as name, for example `b8f7f836-013a-4e32-9070-2efcfab3316b`.
+* Copy a valid bag into that directory, for example:
+
+      dd-dans-sword2-examples/src/main/resources/example-bags/valid/default-open
+
+  Note that `all_mappings` has an invalid prefix for `Has-Organizational-Identifier` in `bag-info.txt`,
+  other bags should be valid.
+
+* Create a file in the same directory named `deposit.properties`, an example for the content
+
+      bag-store.bag-id = b8f7f836-013a-4e32-9070-2efcfab3316b
+      dataverse.bag-id = urn:uuid:b8f7f836-013a-4e32-9070-2efcfab3316b
+      creation.timestamp = 2023-08-16T17:40:41.390209+02:00
+      deposit.origin = SWORD2
+      depositor.userId = user001
+      bag-store.bag-name = default-open
+      dataverse.sword-token = sword:b8f7f836-013a-4e32-9070-2efcfab3316b
+
+  Note that the `bag-name` should match the copied bag and the `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
+
+## Start an ingest
+
+To start an ingest, move (not copy, otherwise the processing might start before the copy the completed)
+a deposit into one of the inboxes configured in:
+
+    dd-vault-ingest-flow/etc/config.yml
+
+You can examine details of the result on the VM in `/var/opt/dans.knaw.nl/tmp/ocfl-tar/inbox`
+and the database: 
+
+    sudo su postgres
+    psql dd_vault_catalog
+
+[dans-dev-tools]: https://github.com/DANS-KNAW/dans-dev-tools#dans-dev-tools

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -113,4 +113,5 @@ and the database:
     select bag_id, data_supplier from transfer_item;
 
 To examine the local database run `start-hsqldb-client.sh`
-and connect with the `database.url` specified in `dd-vault-catalog/etc/config.yml`
+and connect with the `database.url` specified in `dd-vault-catalog/etc/config.yml`,
+the zip files can be found in `dd-vault-ingest-flow/data/rda-bags`.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -63,7 +63,7 @@ start-service.sh
 
 ### Create a deposit
 
-* Create a directory with a `<UUID>` as name, for example `b8f7f836-013a-4e32-9070-2efcfab3316b`.
+* Create a directory with a `<UUID>` as name.
 * Copy a valid bag into that directory, for example:
 
         dd-dans-sword2-examples/src/main/resources/example-bags/valid/default-open
@@ -71,17 +71,20 @@ start-service.sh
   Note that `all_mappings` has an invalid prefix for `Has-Organizational-Identifier` in `bag-info.txt`,
   other bags should be valid.
 
-  * Create a file in the same directory named `deposit.properties`, an example for the content
+  * Create a file in the same directory named `deposit.properties`, an example for the content:
 
-        bag-store.bag-id = b8f7f836-013a-4e32-9070-2efcfab3316b
-        dataverse.bag-id = urn:uuid:b8f7f836-013a-4e32-9070-2efcfab3316b
+        bag-store.bag-id = <UUID>
+        dataverse.bag-id = urn:uuid:<UUID>
+        dataverse.sword-token = sword:<UUID>
         creation.timestamp = 2023-08-16T17:40:41.390209+02:00
         deposit.origin = SWORD2
         depositor.userId = user001
         bag-store.bag-name = default-open
-        dataverse.sword-token = sword:b8f7f836-013a-4e32-9070-2efcfab3316b
 
-    Note that the `bag-name` should match the copied bag and the `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
+    Note that 
+    * The `bag-name` should match the copied bag.
+    * The `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
+    * The `<UUID>` should match the directory name
 
 ## Start an ingest
 
@@ -95,3 +98,6 @@ and the database:
 
     sudo su postgres
     psql dd_vault_catalog
+    select bag_id, data_supplier from ocfl_object_versions;
+    \c dd_transfer_to_vault
+    select bag_id, data_supplier from transfer_item;

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -6,7 +6,7 @@ Set-up
 ------
 This project can be used in combination with  [dans-dev-tools]{:target=_blank}. 
 Before you can start it as a service some dependencies must first be started.
-One depency is [dd-validate-dans-bag]{:target=_blank}.
+One dependency is [dd-validate-dans-bag]{:target=_blank}.
 For the other dependency you have the choice between a local service [dd-vault-catalog]{:target=_blank} and a Virtual Machine (VM) `dev_transfer`.
 The local variant requires a local database. 
 For the VM you need access to the project [dd-dtap]{:target=_blank},
@@ -56,7 +56,7 @@ start-hsqldb-server.sh
 ```
 
 Pick the appropriate `vaultCatalog.url` in `dd-vault-ingest-flow/etc/config.yml`.
-Open terminal tabs for the services `dd-vault-ingest-flow`, `dd-validate-dans-bag`, optionally `dd-vault-catalog` and run in each:
+Open terminal tabs for the services `dd-vault-ingest-flow`, `dd-validate-dans-bag`, optionally (when not using the VM `dev_transfer`) `dd-vault-catalog` and run in each:
 
 ```commandline
 start-service.sh
@@ -64,13 +64,12 @@ start-service.sh
 
 ### Create a deposit
 
-* Create a directory `/vagrant/shared/<UUID>`.
+* Create a directory `/vagrant/shared/<UUID>`, this location makes it available on VMs at `/vagrant/shared`.
 * Copy a valid bag into that directory, for example:
 
         dd-dans-sword2-examples/src/main/resources/example-bags/valid/default-open
 
-  Note that `all_mappings` has an invalid prefix for `Has-Organizational-Identifier` in `bag-info.txt`,
-  other bags should be valid.
+  Note that `all_mappings` has an invalid prefix for `Has-Organizational-Identifier` in `bag-info.txt`.
 
   * Create a file in the same directory named `deposit.properties`, an example for the content:
 
@@ -85,11 +84,14 @@ start-service.sh
     Note that 
     * The `bag-name` should match the copied bag.
     * The `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
-    * The `<UUID>` should match the directory name
-* To test updates you will need different UUIDs for each `example-bags/valid/*`
-  and move them in proper order to the inbox, one by one after the previous completed.
-  Note that the `revision02` and `revision03` bags lack a `Is-Version-Of: <UUID>` in `bag-info.txt`.
+    * The `<UUID>` should match the directory name.
+* To test updates you will need different UUIDs for each `example-bags/valid/*` and move them to the inbox.
+  Note that the `revision02` and `revision03` bags lack an `Is-Version-Of: <UUID>` in `bag-info.txt`.
   Adding this property requires an update of the `tagmanifest-sha1.txt`.
+  A validation error message will show the proper value, for example (with a locally running validator):
+
+      cd dd-dans-sword2-examples
+      ./run-validation.sh http://localhost:20330/validate /vagrant/shared/<UUID>/<bag-name>
 
 ## Start an ingest
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -6,9 +6,10 @@ Set-up
 ------
 This project can be used in combination with  [dans-dev-tools]{:target=_blank}. 
 Before you can start it as a service some dependencies must first be started.
-For one dependency you have the choice between a Virtual Machine (VM) `dev_transfer`
-and a local service `dd-vault-catalog`. For the VM you need access to the project [dd-dtap]{:target=_blank},
-the local service requires a local database.
+One depency is [dd-validate-dans-bag].
+For the other dependency you have the choice between a local service [dd-vault-catalog] and a Virtual Machine (VM) `dev_transfer`.
+The local variant requires a local database. 
+For the VM you need access to the project [dd-dtap]{:target=_blank},
 
 [dans-dev-tools]: https://github.com/DANS-KNAW/dans-dev-tools#readme
 [dd-dtap]: https://github.com/DANS-KNAW/dd-dtap#readme
@@ -19,8 +20,8 @@ the local service requires a local database.
 
 This is only necessary once per project. If you execute this any existing configuration and data will be reset.
 
-Open separate terminal tabs for `dd-vault-ingest-flow`, its dependency [dd-validate-dans-bag]
-and the optional dependency [dd-vault-catalog]. In each tab run:
+Open separate terminal tabs for `dd-vault-ingest-flow`, its dependency `dd-validate-dans-bag`
+and the optional dependency `[dd-vault-catalog`. In each tab run:
 
 ```commandline
 start-env.sh
@@ -43,7 +44,7 @@ if not, keep the URLs as generated from `src/test/resources/debug-etc`.
 
 ### Start services
 
-To start the VM run in the root of `dd-dtap`:
+To start the VM, run in the root of `dd-dtap`:
 
 ```commandline
 start-preprovisioned-box.py -s dev_transfer
@@ -55,7 +56,8 @@ Without the VM you will need a local database for the service `dd-vault-catalog`
 start-hsqldb-server.sh
 ```
 
-Open terminal tabs for the services `dd-vault-ingest-flow`, `dd-validate-dans-bag`, optionally `dd-vault-catalog` and run:
+Pick the appropriate `vaultCatalog.url` in `dd-vault-ingest-flow/etc/config.yml`.
+Open terminal tabs for the services `dd-vault-ingest-flow`, `dd-validate-dans-bag`, optionally `dd-vault-catalog` and run in each:
 
 ```commandline
 start-service.sh
@@ -85,13 +87,21 @@ start-service.sh
     * The `bag-name` should match the copied bag.
     * The `userId` should match a value configured as a `dataSupplier` in `dd-vault-ingest-flow/etc/config.yml`.
     * The `<UUID>` should match the directory name
+* When using the deposit on a VM, create it at `dd-dtap/shared/<UUID>`, on the VM
+
+      cd /vagrant/shared/<UUID> ; chgrp -R deposits . ; chown -R dd-vault-ingest-flow .
+* To test updates you will need different UUIDs for each `example-bags/valid/revision*`
+  and move them in proper order to the inbox, one by one after the previous completed.
 
 ## Start an ingest
 
-To start an ingest, move (not copy, otherwise the processing might start before the copy the completed)
+To start an ingest locally, move (not copy, otherwise the processing might start before the copy the completed)
 a deposit into one of the inboxes configured in:
 
     dd-vault-ingest-flow/etc/config.yml
+
+To start an ingest on the VM, move it to `/var/opt/dans.knaw.nl/tmp/auto-ingest/inbox`
+as configured in `/etc/opt/dans.knaw.nl/dd-vault-ingest-flow/config.yml` 
 
 You can examine details of the result on the VM in `/var/opt/dans.knaw.nl/tmp/ocfl-tar/inbox`
 and the database: 
@@ -101,3 +111,6 @@ and the database:
     select bag_id, data_supplier from ocfl_object_versions;
     \c dd_transfer_to_vault
     select bag_id, data_supplier from transfer_item;
+
+To examine the local database run `start-hsqldb-client.sh`
+and connect with the `database.url` specified in `dd-vault-catalog/etc/config.yml`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ repo_url: https://github.com/DANS-KNAW/dd-vault-ingest-flow
 
 nav:
   - Manual: index.md
+  - Development: dev.md
   - ⇒ DANS Data Station Architecture: arch.md
 
 extra:

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -25,13 +25,13 @@ ingestFlow:
   rdaBagOutputDir: /var/opt/dans.knaw.nl/tmp/rda-bag
   autoIngest:
     dataSuppliers:
-      USER001: The Organization Name
+      user001: The Organization Name
     # todo: how to check if an update is authorized?
     inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox
   migration:
     dataSuppliers:
-      USER001: The Organization Name
+      user001: The Organization Name
     inbox: /var/opt/dans.knaw.nl/tmp/migration/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/migration/outbox
   languages:

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -28,6 +28,8 @@ ingestFlow:
     inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox
   migration:
+    dataSuppliers:
+      USER001: The Organization Name
     inbox: /var/opt/dans.knaw.nl/tmp/migration/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/migration/outbox
   languages:

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -24,6 +24,8 @@ health:
 ingestFlow:
   rdaBagOutputDir: /var/opt/dans.knaw.nl/tmp/rda-bag
   autoIngest:
+    dataSuppliers:
+      USER001: The Organization Name
     # todo: how to check if an update is authorized?
     inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -49,7 +49,8 @@ ingestFlow:
     keepAliveTime: 60 seconds
 
 vaultCatalog:
-  url: https://vault.dans.knaw.nl/catalog
+#  url: https://vault.dans.knaw.nl/catalog
+  url:  https://dev.transfer.dans-data.nl
   httpClient:
     userAgent: dd-vault-ingest-flow
     connectionTimeout: 1min

--- a/src/main/java/nl/knaw/dans/vaultingest/DdVaultIngestFlowApplication.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/DdVaultIngestFlowApplication.java
@@ -132,7 +132,8 @@ public class DdVaultIngestFlowApplication extends Application<DdVaultIngestFlowC
             taskQueue,
             migrationDepositToBagProcess,
             configuration.getIngestFlow().getMigration().getInbox(),
-            new DepositOutbox(configuration.getIngestFlow().getMigration().getOutbox())
+            new DepositOutbox(configuration.getIngestFlow().getMigration().getOutbox()),
+            configuration.getIngestFlow().getMigration().getDataSuppliers()
         );
 
         inboxListener.start();

--- a/src/main/java/nl/knaw/dans/vaultingest/DdVaultIngestFlowApplication.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/DdVaultIngestFlowApplication.java
@@ -113,8 +113,8 @@ public class DdVaultIngestFlowApplication extends Application<DdVaultIngestFlowC
             taskQueue,
             ingestAreaDirectoryWatcher,
             depositToBagProcess,
-            autoIngestOutbox
-        );
+            autoIngestOutbox,
+            configuration.getIngestFlow().getAutoIngest().getDataSuppliers());
 
         var migrationDepositValidator = new MigrationBagValidator(dansBagValidatorClient, configuration.getValidateDansBag().getValidateUrl());
         var migrationDepositManager = new MigrationDepositManager(xmlReader);

--- a/src/main/java/nl/knaw/dans/vaultingest/client/VaultCatalogClient.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/client/VaultCatalogClient.java
@@ -51,7 +51,7 @@ public class VaultCatalogClient implements VaultCatalogRepository {
             var parameters = new OcflObjectVersionParametersDto()
                 .skeletonRecord(true)
                 .nbn(deposit.getNbn())
-                .dataSupplier(deposit.getDepositorId())
+                .dataSupplier(deposit.getDataSupplier())
                 .swordToken(deposit.getSwordToken());
 
             var newVersion = highestVersion + 1;

--- a/src/main/java/nl/knaw/dans/vaultingest/config/InboxConfig.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/config/InboxConfig.java
@@ -18,9 +18,11 @@ package nl.knaw.dans.vaultingest.config;
 import lombok.Getter;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 @Getter
 public class InboxConfig {
     private Path inbox;
     private Path outbox;
+    private Map<String, String> dataSuppliers;
 }

--- a/src/main/java/nl/knaw/dans/vaultingest/config/IngestFlowConfig.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/config/IngestFlowConfig.java
@@ -21,6 +21,7 @@ import nl.knaw.dans.lib.util.ExecutorServiceFactory;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.nio.file.Path;
+import java.util.Map;
 
 @Getter
 public class IngestFlowConfig {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
@@ -90,9 +90,9 @@ public class DepositToBagProcess {
                 .orElseThrow(() -> new InvalidDepositException(String.format("Deposit with sword token %s not found in vault catalog", deposit.getSwordToken())));
 
             // compare user id
-            if (!StringUtils.equals(deposit.getDepositorId(), catalogDeposit.getDataSupplier())) {
+            if (!StringUtils.equals(deposit.getDataSupplier(), catalogDeposit.getDataSupplier())) {
                 throw new InvalidDepositException(String.format(
-                    "Depositor id %s does not match the depositor id %s in the vault catalog", deposit.getDepositorId(), catalogDeposit.getDataSupplier()
+                    "Data supplier in deposit  %s does not match the data supplier %s in the vault catalog", deposit.getDataSupplier(), catalogDeposit.getDataSupplier()
                 ));
             }
 

--- a/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
 @Slf4j
 public class DepositToBagProcess {
@@ -57,7 +58,7 @@ public class DepositToBagProcess {
         this.depositManager = depositManager;
     }
 
-    public void process(Path path, Outbox outbox) {
+    public void process(Path path, Outbox outbox, Map<String, String> dataSupplierMap) {
         try {
             var bagDir = getBagDir(path);
 
@@ -65,7 +66,8 @@ public class DepositToBagProcess {
             bagValidator.validate(bagDir);
 
             log.info("Loading deposit on path {}", path);
-            var deposit = depositManager.loadDeposit(path);
+            var deposit = depositManager.loadDeposit(path, dataSupplierMap);
+            deposit.setDataSupplier(dataSupplierMap.get(deposit.getDepositorId()));
             processDeposit(deposit);
 
             log.info("Deposit {} processed successfully", deposit.getId());

--- a/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/DepositToBagProcess.java
@@ -67,7 +67,6 @@ public class DepositToBagProcess {
 
             log.info("Loading deposit on path {}", path);
             var deposit = depositManager.loadDeposit(path, dataSupplierMap);
-            deposit.setDataSupplier(dataSupplierMap.get(deposit.getDepositorId()));
             processDeposit(deposit);
 
             log.info("Deposit {} processed successfully", deposit.getId());

--- a/src/main/java/nl/knaw/dans/vaultingest/core/deposit/Deposit.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/deposit/Deposit.java
@@ -44,6 +44,7 @@ public class Deposit {
     private final boolean migration;
     private String nbn;
     private Long objectVersion;
+    private String dataSupplier;
 
     public Path getPath() {
         return path;
@@ -123,6 +124,7 @@ public class Deposit {
     }
 
     public Collection<DepositFile> getPayloadFiles() {
+        // TODO why these inconsistent names, it seems to prevent @Getter
         return depositFiles;
     }
 
@@ -166,6 +168,14 @@ public class Deposit {
 
     public void setObjectVersion(Long objectVersion) {
         this.objectVersion = objectVersion;
+    }
+
+    public void setDataSupplier(String dataSupplier) {
+        this.dataSupplier = dataSupplier;
+    }
+
+    public String getDataSupplier() {
+        return dataSupplier;
     }
 
     public enum State {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/deposit/DepositManager.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/deposit/DepositManager.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 public class DepositManager {
     private final XmlReader xmlReader;
 
-    public Deposit loadDeposit(Path path) {
+    public Deposit loadDeposit(Path path, Map<String, String> dataSupplierMap) {
         try {
             var bagDir = getBagDir(path);
 
@@ -68,6 +68,12 @@ public class DepositManager {
             log.info("Generating payload file list on path {}", path);
             var depositFiles = getDepositFiles(bagDir, bag, ddm, filesXml, originalFilePaths);
 
+            final String depositorId = depositProperties.getDepositorId();
+            log.info("Looking up dataSupplier for depositorId {}", depositorId);
+            if (!dataSupplierMap.containsKey(depositorId))
+                throw new Exception(String.format("No mapping to Data Supplier found for user id '%s'.", depositorId));
+            var dataSupplier = dataSupplierMap.get(depositorId);
+
             var builder = Deposit.builder()
                 .id(path.getFileName().toString())
                 .path(path)
@@ -75,7 +81,8 @@ public class DepositManager {
                 .bag(new DepositBag(bag))
                 .filesXml(filesXml)
                 .depositFiles(depositFiles)
-                .properties(depositProperties);
+                .properties(depositProperties)
+                .dataSupplier(dataSupplier);
 
             builder = customizeDeposit(builder, depositProperties);
 

--- a/src/main/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestArea.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestArea.java
@@ -29,17 +29,18 @@ public class AutoIngestArea {
     private final IngestAreaWatcher ingestAreaWatcher;
     private final DepositToBagProcess depositToBagProcess;
     private final Outbox outbox;
-    private final Map<String, String> dataSupplierMap = Map.of();
+    private final Map<String, String> dataSupplierMap;
 
     public AutoIngestArea(
         Executor executor,
         IngestAreaWatcher ingestAreaWatcher,
         DepositToBagProcess depositToBagProcess,
-        Outbox outbox) {
+        Outbox outbox, Map<String, String> dataSupplierMap) {
         this.executor = executor;
         this.ingestAreaWatcher = ingestAreaWatcher;
         this.depositToBagProcess = depositToBagProcess;
         this.outbox = outbox;
+        this.dataSupplierMap = dataSupplierMap;
     }
 
     public void start() {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestArea.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestArea.java
@@ -35,7 +35,8 @@ public class AutoIngestArea {
         Executor executor,
         IngestAreaWatcher ingestAreaWatcher,
         DepositToBagProcess depositToBagProcess,
-        Outbox outbox, Map<String, String> dataSupplierMap) {
+        Outbox outbox,
+        Map<String, String> dataSupplierMap) {
         this.executor = executor;
         this.ingestAreaWatcher = ingestAreaWatcher;
         this.depositToBagProcess = depositToBagProcess;

--- a/src/main/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestArea.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestArea.java
@@ -20,6 +20,7 @@ import nl.knaw.dans.vaultingest.core.DepositToBagProcess;
 import nl.knaw.dans.vaultingest.core.deposit.Outbox;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 @Slf4j
@@ -28,6 +29,7 @@ public class AutoIngestArea {
     private final IngestAreaWatcher ingestAreaWatcher;
     private final DepositToBagProcess depositToBagProcess;
     private final Outbox outbox;
+    private final Map<String, String> dataSupplierMap = Map.of();
 
     public AutoIngestArea(
         Executor executor,
@@ -47,7 +49,7 @@ public class AutoIngestArea {
             ingestAreaWatcher.start((path) -> {
                 log.info("New item in inbox; path = {}", path);
 
-                executor.execute(() -> depositToBagProcess.process(path, outbox));
+                executor.execute(() -> depositToBagProcess.process(path, outbox, dataSupplierMap));
             });
         }
         catch (IOException e) {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/inbox/MigrationIngestArea.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/inbox/MigrationIngestArea.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -33,17 +34,18 @@ public class MigrationIngestArea {
     private final DepositToBagProcess depositToBagProcess;
     private final Path inboxPath;
     private final Outbox outbox;
+    private final Map<String, String> dataSupplierMap;
 
     public MigrationIngestArea(
         ExecutorService executorService,
         DepositToBagProcess depositToBagProcess,
         Path inboxPath,
-        Outbox outbox
-    ) {
+        Outbox outbox, Map<String, String> dataSupplierMap) {
         this.executorService = executorService;
         this.depositToBagProcess = depositToBagProcess;
         this.inboxPath = inboxPath.toAbsolutePath();
         this.outbox = outbox;
+        this.dataSupplierMap = dataSupplierMap;
     }
 
     public void ingest(Path inputPath, boolean isBatch, boolean continuePrevious) {
@@ -69,7 +71,7 @@ public class MigrationIngestArea {
             output.init(!isBatch || continuePrevious);
 
             for (var in : input) {
-                executorService.execute(() -> depositToBagProcess.process(in, output));
+                executorService.execute(() -> depositToBagProcess.process(in, output, dataSupplierMap));
             }
         }
         catch (IOException e) {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/inbox/MigrationIngestArea.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/inbox/MigrationIngestArea.java
@@ -40,7 +40,8 @@ public class MigrationIngestArea {
         ExecutorService executorService,
         DepositToBagProcess depositToBagProcess,
         Path inboxPath,
-        Outbox outbox, Map<String, String> dataSupplierMap) {
+        Outbox outbox,
+            Map<String, String> dataSupplierMap) {
         this.executorService = executorService;
         this.depositToBagProcess = depositToBagProcess;
         this.inboxPath = inboxPath.toAbsolutePath();

--- a/src/main/java/nl/knaw/dans/vaultingest/core/mappings/VaultMetadata.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/mappings/VaultMetadata.java
@@ -15,14 +15,17 @@
  */
 package nl.knaw.dans.vaultingest.core.mappings;
 
+import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.vaultingest.core.deposit.Deposit;
 import nl.knaw.dans.vaultingest.core.mappings.vocabulary.DansDVMetadata;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 public class VaultMetadata extends Base {
 
     public static List<Statement> toRDF(Resource resource, Deposit deposit) {
@@ -45,9 +48,14 @@ public class VaultMetadata extends Base {
             .ifPresent(result::add);
 
         // VLT008
-        toBasicTerm(resource, DansDVMetadata.dansDataSupplier, deposit.getDepositorId())
-            .ifPresent(result::add);
-
+        String dataSupplier = deposit.getDataSupplier();
+        if (StringUtils.isBlank(dataSupplier)) {
+            log.warn("No mapping to Data Supplier found for user id '{}'. The field dansDataSupplier will be left empty", deposit.getDepositorId());
+        }
+        else {
+            toBasicTerm(resource, DansDVMetadata.dansDataSupplier, dataSupplier)
+                .ifPresent(result::add);
+        }
         return result;
     }
 

--- a/src/test/java/nl/knaw/dans/vaultingest/core/ConfigurationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/ConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.vaultingest.core;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import nl.knaw.dans.vaultingest.DdVaultIngestFlowConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class ConfigurationTest {
+
+    private final Path testDir = new File("target/test/" + getClass().getSimpleName()).toPath();
+
+    @BeforeEach
+    void clear() throws IOException {
+        FileUtils.deleteQuietly(testDir.toFile());
+    }
+    private final YamlConfigurationFactory<DdVaultIngestFlowConfiguration> factory;
+
+    {
+        final var mapper = Jackson.newObjectMapper().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        factory = new YamlConfigurationFactory<>(DdVaultIngestFlowConfiguration.class, Validators.newValidator(), mapper, "dw");
+    }
+
+    @Test
+    public void assembly_dist_cfg_does_not_throw() throws IOException {
+        File cfgFile = testDir.resolve("config.yml").toFile();
+        FileUtils.write(cfgFile, rewriteFilePaths("src/main/assembly/dist/cfg/config.yml"), StandardCharsets.UTF_8);
+        assertDoesNotThrow(() -> factory.build(FileInputStream::new, cfgFile.toString()));
+    }
+
+    @Test
+    public void debug_etc_does_not_throw() throws IOException {
+        File cfgFile = testDir.resolve("config.yml").toFile();
+        FileUtils.write(cfgFile, rewriteFilePaths("src/test/resources/debug-etc/config.yml"), StandardCharsets.UTF_8);
+        assertDoesNotThrow(() -> factory.build(FileInputStream::new, cfgFile.toString()));
+    }
+
+    private String rewriteFilePaths(String pathname) throws IOException {
+        // prevent ConfigurationValidationException ... does not exist but is required
+        // TODO why not @FileMustExist for other files and dirs?
+        return FileUtils.readFileToString(new File(pathname), StandardCharsets.UTF_8)
+            .replaceAll("(iso639[12]): .*/","$1: src/main/assembly/dist/cfg/");
+    }
+}

--- a/src/test/java/nl/knaw/dans/vaultingest/core/ConfigurationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/ConfigurationTest.java
@@ -65,6 +65,6 @@ public class ConfigurationTest {
         // prevent ConfigurationValidationException ... does not exist but is required
         // TODO why not @FileMustExist for other files and dirs?
         return FileUtils.readFileToString(new File(pathname), StandardCharsets.UTF_8)
-            .replaceAll("(iso639[12]): .*/","$1: src/main/assembly/dist/cfg/");
+            .replaceAll(": /etc/opt/dans.knaw.nl/dd-vault-ingest-flow/",": src/main/assembly/dist/cfg/");
     }
 }

--- a/src/test/java/nl/knaw/dans/vaultingest/core/ConfigurationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/ConfigurationTest.java
@@ -61,10 +61,10 @@ public class ConfigurationTest {
         assertDoesNotThrow(() -> factory.build(FileInputStream::new, cfgFile.toString()));
     }
 
-    private String rewriteFilePaths(String pathname) throws IOException {
+    private String rewriteFilePaths(String configYmlContent) throws IOException {
         // prevent ConfigurationValidationException ... does not exist but is required
-        // TODO why not @FileMustExist for other files and dirs?
-        return FileUtils.readFileToString(new File(pathname), StandardCharsets.UTF_8)
-            .replaceAll(": /etc/opt/dans.knaw.nl/dd-vault-ingest-flow/",": src/main/assembly/dist/cfg/");
+        // TODO why only @FileMustExist for the language files?
+        return FileUtils.readFileToString(new File(configYmlContent), StandardCharsets.UTF_8)
+            .replaceAll("(iso639[12]): .*/","$1: src/main/assembly/dist/cfg/");
     }
 }

--- a/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
@@ -289,7 +289,7 @@ class DepositToBagProcessTest {
 
         var outbox = Mockito.mock(Outbox.class);
 
-        depositToBagProcess.process(Path.of("input/path/"), outbox);
+        depositToBagProcess.process(Path.of("input/path/"), outbox, Map.of("user001","Name of user"));
 
         assertThat(output.getData().entrySet())
             .extracting(Map.Entry::getKey)

--- a/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/DepositToBagProcessTest.java
@@ -68,7 +68,7 @@ class DepositToBagProcessTest {
 
         var outbox = Mockito.mock(Outbox.class);
 
-        depositToBagProcess.process(Path.of("input/path/"), outbox);
+        depositToBagProcess.process(Path.of("input/path/"), outbox, Map.of());
 
         Mockito.verify(outbox).moveDeposit(Mockito.any());
 
@@ -90,7 +90,7 @@ class DepositToBagProcessTest {
             .thenReturn(VaultCatalogDeposit.builder().objectVersion(1L).build());
 
         var depositManager = Mockito.spy(TestDepositManager.ofDeposit(null));
-        Mockito.doThrow(new RuntimeException("error")).when(depositManager).loadDeposit(Mockito.any());
+        Mockito.doThrow(new RuntimeException("error")).when(depositManager).loadDeposit(Mockito.any(), Mockito.any());
 
         var depositToBagProcess = new DepositToBagProcess(
             () -> rdaBagWriter,
@@ -102,7 +102,7 @@ class DepositToBagProcessTest {
 
         var outbox = Mockito.mock(Outbox.class);
 
-        depositToBagProcess.process(Path.of("input/path/"), outbox);
+        depositToBagProcess.process(Path.of("input/path/"), outbox, Map.of());
         Mockito.verify(outbox).move(Path.of("input/path/"), Deposit.State.FAILED);
 
         assertThat(depositManager.getLastState()).isEqualTo(Deposit.State.FAILED);
@@ -134,7 +134,7 @@ class DepositToBagProcessTest {
 
         var outbox = Mockito.mock(Outbox.class);
 
-        depositToBagProcess.process(Path.of("input/path/"), outbox);
+        depositToBagProcess.process(Path.of("input/path/"), outbox, Map.of());
         Mockito.verify(outbox).move(Path.of("input/path/"), Deposit.State.REJECTED);
 
         assertThat(depositManager.getLastState()).isEqualTo(Deposit.State.REJECTED);
@@ -166,7 +166,7 @@ class DepositToBagProcessTest {
 
         var outbox = Mockito.mock(Outbox.class);
 
-        depositToBagProcess.process(Path.of("input/path/"), outbox);
+        depositToBagProcess.process(Path.of("input/path/"), outbox, Map.of());
         Mockito.verify(outbox).move(Path.of("input/path/"), Deposit.State.REJECTED);
 
         assertThat(depositManager.getLastState()).isEqualTo(Deposit.State.REJECTED);
@@ -303,12 +303,12 @@ class DepositToBagProcessTest {
 
     private Deposit getBasicDeposit() {
         var manager = new TestDepositManager();
-        return manager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"));
+        return manager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"), Map.of("user001","Name of user"));
     }
 
     private Deposit getBasicDepositAsUpdate() {
         var manager = new TestDepositManager();
-        var deposit = manager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"));
+        var deposit = manager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"), Map.of("user001","Name of user"));
 
         var spied = Mockito.spy(deposit);
 

--- a/src/test/java/nl/knaw/dans/vaultingest/core/deposit/CommonDepositManagerIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/deposit/CommonDepositManagerIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class CommonDepositManagerIntegrationTest {
 
@@ -44,7 +45,7 @@ class CommonDepositManagerIntegrationTest {
         var manager = new DepositManager(new XmlReader());
 
         var s = getClass().getResource("/input/0b9bb5ee-3187-4387-bb39-2c09536c79f7");
-        assert s != null;
+        assertNotNull(s);
 
         assertThatThrownBy(() ->  manager.loadDeposit(Path.of(s.getPath()), Map.of()))
             .hasMessage("java.lang.Exception: No mapping to Data Supplier found for user id 'user001'.");

--- a/src/test/java/nl/knaw/dans/vaultingest/core/deposit/CommonDepositManagerIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/deposit/CommonDepositManagerIntegrationTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CommonDepositManagerIntegrationTest {
 
@@ -36,6 +37,17 @@ class CommonDepositManagerIntegrationTest {
 
         var deposit = manager.loadDeposit(Path.of(s.getPath()), Map.of("user001","Name of user"));
         assertThat(deposit.getId()).isEqualTo("0b9bb5ee-3187-4387-bb39-2c09536c79f7");
+    }
+
+    @Test
+    void loadDeposit_should_complain_about_missing_data_supplier() {
+        var manager = new DepositManager(new XmlReader());
+
+        var s = getClass().getResource("/input/0b9bb5ee-3187-4387-bb39-2c09536c79f7");
+        assert s != null;
+
+        assertThatThrownBy(() ->  manager.loadDeposit(Path.of(s.getPath()), Map.of()))
+            .hasMessage("java.lang.Exception: No mapping to Data Supplier found for user id 'user001'.");
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/vaultingest/core/deposit/CommonDepositManagerIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/deposit/CommonDepositManagerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,7 +34,7 @@ class CommonDepositManagerIntegrationTest {
         var s = getClass().getResource("/input/0b9bb5ee-3187-4387-bb39-2c09536c79f7");
         assert s != null;
 
-        var deposit = manager.loadDeposit(Path.of(s.getPath()));
+        var deposit = manager.loadDeposit(Path.of(s.getPath()), Map.of("user001","Name of user"));
         assertThat(deposit.getId()).isEqualTo("0b9bb5ee-3187-4387-bb39-2c09536c79f7");
     }
 
@@ -48,7 +49,7 @@ class CommonDepositManagerIntegrationTest {
         // first verify there is actually an original-filepaths.txt file
         assertThat(Files.exists(path.resolve("audiences/original-filepaths.txt"))).isTrue();
 
-        var deposit = manager.loadDeposit(path);
+        var deposit = manager.loadDeposit(path, Map.of("user001","Name of user"));
         var files = deposit.getPayloadFiles();
 
         // check that the file paths are the original ones, not the renamed ones

--- a/src/test/java/nl/knaw/dans/vaultingest/core/deposit/DepositOutboxTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/deposit/DepositOutboxTest.java
@@ -143,7 +143,7 @@ class DepositOutboxTest {
         private final Deposit.State state;
 
         DepositWithPathAndState(Path path, State state) {
-            super("random_id", null, null, null, path, null, null, false, null, null);
+            super("random_id", null, null, null, path, null, null, false, null, null, null);
             this.state = state;
         }
 

--- a/src/test/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestAreaTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestAreaTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 class AutoIngestAreaTest {
 
@@ -39,6 +40,6 @@ class AutoIngestAreaTest {
 
         area.start();
 
-        Mockito.verify(process).process(Path.of("fake/path"), outbox);
+        Mockito.verify(process).process(Path.of("fake/path"), outbox, Map.of());
     }
 }

--- a/src/test/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestAreaTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/inbox/AutoIngestAreaTest.java
@@ -35,8 +35,8 @@ class AutoIngestAreaTest {
             Runnable::run,
             callback -> callback.onItemCreated(Path.of("fake/path")),
             process,
-            outbox
-        );
+            outbox,
+            Map.of());
 
         area.start();
 

--- a/src/test/java/nl/knaw/dans/vaultingest/core/inbox/MigrationIngestAreaTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/inbox/MigrationIngestAreaTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +37,7 @@ class MigrationIngestAreaTest {
         var executor = Mockito.mock(ExecutorService.class);
         var process = Mockito.mock(DepositToBagProcess.class);
         var outbox = new TestOutbox(Path.of("/outbox/path/"));
-        var area = new MigrationIngestArea(executor, process, Path.of("/input/path/"), outbox);
+        var area = new MigrationIngestArea(executor, process, Path.of("/input/path/"), outbox, Map.of());
 
         var result = area.getAbsolutePath(Path.of("batch1"));
         assertThat(result).isEqualTo(Path.of("/input/path/batch1"));
@@ -47,7 +48,7 @@ class MigrationIngestAreaTest {
         var executor = Mockito.mock(ExecutorService.class);
         var process = Mockito.mock(DepositToBagProcess.class);
         var outbox = new TestOutbox(Path.of("/outbox/path/"));
-        var area = new MigrationIngestArea(executor, process, Path.of("/input/path/"), outbox);
+        var area = new MigrationIngestArea(executor, process, Path.of("/input/path/"), outbox, Map.of());
 
         var result = area.getAbsolutePath(Path.of("/this/is/absolute"));
         assertThat(result).isEqualTo(Path.of("/this/is/absolute"));
@@ -60,7 +61,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
             var path = fs.getPath("/input/path/batch1/deposit1");
             Files.createDirectories(path);
             Files.write(path.resolve("deposit.properties"), "state=FAILED".getBytes());
@@ -76,7 +77,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
             var path = fs.getPath("/input/path/batch1/deposit1");
             Files.createDirectories(path);
 
@@ -93,7 +94,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
 
             var path = fs.getPath("/input/path/batch1/");
             Files.createDirectories(path.resolve("deposit1"));
@@ -112,7 +113,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
 
             var path = fs.getPath("/input/path/batch1/");
             Files.createDirectories(path.resolve("deposit1"));
@@ -133,7 +134,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
 
             var path = fs.getPath("/input/path/batch1");
             Files.createDirectories(path.getParent());
@@ -152,7 +153,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
 
             var path = fs.getPath("/input/path/batch1/");
             Files.createDirectories(path.resolve("deposit1"));
@@ -173,7 +174,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
 
             var path = fs.getPath("/random/other/deposit1");
             Files.createDirectories(path);
@@ -193,7 +194,7 @@ class MigrationIngestAreaTest {
 
         try (var fs = MemoryFileSystemBuilder.newLinux().build()) {
             var outbox = new TestOutbox(fs.getPath("/outbox/path/"));
-            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox);
+            var area = new MigrationIngestArea(executor, process, fs.getPath("/input/path/"), outbox, Map.of());
 
             var path = fs.getPath("/input/path/deposit1");
             Files.createDirectories(path);

--- a/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/DataciteConverterIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/DataciteConverterIntegrationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,7 +117,7 @@ class DataciteConverterIntegrationTest {
     // serialize to XML, then convert to Node, so we can use XPath to test the output
     private Document loadResource() throws Exception {
         var manager = new TestDepositManager();
-        var deposit = manager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"));
+        var deposit = manager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"), Map.of("user001","Name of user"));
 
         var resource = new DataciteConverter().convert(deposit);
         var xmlString = new DataciteSerializer().serialize(resource);

--- a/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/OaiOreConverterIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/OaiOreConverterIntegrationTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -636,7 +637,7 @@ public class OaiOreConverterIntegrationTest {
 
     private ModelObject loadModel() throws Exception {
         var depositManager = new TestDepositManager();
-        var deposit = depositManager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"));
+        var deposit = depositManager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"), Map.of("user001","Name of user"));
         deposit.setNbn("urn:nbn:nl:ui:13-4c-1a2b");
 
         var model = new OaiOreConverter(

--- a/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/RdaBagWriterTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/rdabag/RdaBagWriterTest.java
@@ -29,6 +29,7 @@ import nl.knaw.dans.vaultingest.core.utilities.TestDepositManager;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,7 +47,7 @@ class RdaBagWriterTest {
         );
 
         var manager = new TestDepositManager();
-        var deposit = manager.loadDeposit(Path.of("/input/bag-md5/c169676f-5315-4d86-bde0-a62dbc915228"));
+        var deposit = manager.loadDeposit(Path.of("/input/bag-md5/c169676f-5315-4d86-bde0-a62dbc915228"), Map.of("user001","Name of user"));
         var output = new InMemoryOutputWriter();
         writer.write(deposit, output);
 
@@ -70,7 +71,7 @@ class RdaBagWriterTest {
         );
 
         var manager = new TestDepositManager();
-        var deposit = manager.loadDeposit(Path.of("/input/bag-sha1/c169676f-5315-4d86-bde0-a62dbc915228"));
+        var deposit = manager.loadDeposit(Path.of("/input/bag-sha1/c169676f-5315-4d86-bde0-a62dbc915228"),Map.of("user001","Name of user"));
         var output = new InMemoryOutputWriter();
         writer.write(deposit, output);
 

--- a/src/test/java/nl/knaw/dans/vaultingest/core/utilities/TestDepositManager.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/utilities/TestDepositManager.java
@@ -20,6 +20,7 @@ import nl.knaw.dans.vaultingest.core.deposit.DepositManager;
 import nl.knaw.dans.vaultingest.core.xml.XmlReader;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 public class TestDepositManager extends DepositManager {
     private Deposit deposit;
@@ -49,7 +50,7 @@ public class TestDepositManager extends DepositManager {
     }
 
     @Override
-    public Deposit loadDeposit(Path path) {
+    public Deposit loadDeposit(Path path, Map<String, String> dataSupplierMap) {
         if (this.deposit != null) {
             return this.deposit;
         }
@@ -57,7 +58,7 @@ public class TestDepositManager extends DepositManager {
         var resource = getClass().getResource(path.toString());
         assert resource != null;
         var resourcePath = Path.of(resource.getPath());
-        return super.loadDeposit(resourcePath);
+        return super.loadDeposit(resourcePath, dataSupplierMap);
     }
 
     @Override

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -26,7 +26,7 @@ ingestFlow:
   rdaBagOutputDir: data/rda-bag
   autoIngest:
     dataSuppliers:
-      USER001: The Organization Name
+      user001: The Organization Name
     # todo: how to check if an update is authorized?
     inbox: data/inbox
     outbox: data/outbox
@@ -50,9 +50,12 @@ ingestFlow:
     keepAliveTime: 60 seconds
 
 vaultCatalog:
-  url: http://localhost:20305/catalog
+  url: http://localhost:20305/
   httpClient:
     userAgent: dd-vault-ingest-flow
+    timeout: 5min
+    connectionTimeout: 1min
+
 
 #
 # See https://www.dropwizard.io/en/latest/manual/configuration.html#logging

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -25,6 +25,8 @@ health:
 ingestFlow:
   rdaBagOutputDir: data/rda-bag
   autoIngest:
+    dataSuppliers:
+      USER001: The Organization Name
     # todo: how to check if an update is authorized?
     inbox: data/inbox
     outbox: data/outbox

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -50,7 +50,8 @@ ingestFlow:
     keepAliveTime: 60 seconds
 
 vaultCatalog:
-  url: http://localhost:20305/
+  url: https://dev.transfer.dans-data.nl/vault-catalog
+  # url: http://localhost:20305/
   httpClient:
     userAgent: dd-vault-ingest-flow
     timeout: 5min

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -50,7 +50,7 @@ ingestFlow:
     keepAliveTime: 60 seconds
 
 vaultCatalog:
-  url: https://vault.dans.knaw.nl/catalog
+  url: http://localhost:20305/catalog
   httpClient:
     userAgent: dd-vault-ingest-flow
 

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -29,6 +29,8 @@ ingestFlow:
     inbox: data/inbox
     outbox: data/outbox
   migration:
+    dataSuppliers:
+      user001: The Organization Name
     inbox: data/migration-inbox
     outbox: data/migration-outbox
   languages:


### PR DESCRIPTION
Fixes DD-1356: map depositorId to dataSupplier

# Description of changes



# How to test

* build,  also dd-validate-dans-bag after `rm -rf application api`
* `start-preprovisioned-box.py dev_transfer`
* `deploy.py -m dd-vault-ingest-flow dev_vaas` as well as `dd-validate-dans-bag`
* further instructions under set-up in `dev.md`

Checks on dev_transfer:
  * [x] DB shows user name (`sudo su postgres`; `psql dd_vault_catalog`; `select bag_id, data_supplier from ocfl_object_versions`)
  * [x] `/var/opt/dans.knaw.nl/tmp/ocfl-tar/inbox/vaas-<UUID>-v2-ttv2.zip` shows the user name in `metadata/oai-ore.*`

The fully local test shows the same DB values and ZIP details.


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
