### PR TITLE
DD-1491 dd-vault-ingest-flow: implement rule CIT025B

### DIFF
--- a/src/main/java/nl/knaw/dans/vaultingest/core/mappings/DepositDate.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/mappings/DepositDate.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.vaultingest.core.mappings;
+
+import nl.knaw.dans.vaultingest.core.deposit.Deposit;
+import nl.knaw.dans.vaultingest.core.mappings.vocabulary.DVCitation;
+import nl.knaw.dans.vaultingest.core.xml.XPathEvaluator;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.w3c.dom.Document;
+
+import java.util.Optional;
+
+public class DepositDate extends Base {
+    private static final DateTimeFormatter yyyymmddPattern = DateTimeFormat.forPattern("YYYY-MM-dd");
+
+    public static Optional<Statement> toRDF(Resource resource, Deposit deposit) {
+        return toDepositDate(resource, getDepositDate(deposit.getDdm()));
+    }
+
+    static String getDepositDate(Document document) {
+        return XPathEvaluator.strings(document, "/ddm:DDM/ddm:dcmiMetadata/dcterms:dateSubmitted")
+            .findFirst()
+            .map(DepositDate::toYearMonthDayFormat)
+            .orElse(null); //TODO : NOW
+    }
+
+    static String toYearMonthDayFormat(String text) {
+        var date = DateTime.parse(text);
+        return yyyymmddPattern.print(date);
+    }
+
+    static Optional<Statement> toDepositDate(Resource resource, String dipositDate) {
+        return toBasicTerm(resource, DVCitation.dateOfDeposit, dipositDate);
+    }
+}

--- a/src/main/java/nl/knaw/dans/vaultingest/core/mappings/vocabulary/DVCitation.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/mappings/vocabulary/DVCitation.java
@@ -49,6 +49,7 @@ public class DVCitation {
     public static final Property distributor = m.createProperty(NS, "distributor");
     public static final Property distributorName = m.createProperty(NS, "distributorName");
     public static final Property distributionDate = m.createProperty(NS, "distributionDate");
+    public static final Property dateOfDeposit = m.createProperty(NS, "Property");
     public static final Property dateOfCollection = m.createProperty(NS, "dateOfCollection");
     public static final Property dateOfCollectionStart = m.createProperty(NS, "dateOfCollectionStart");
     public static final Property dateOfCollectionEnd = m.createProperty(NS, "dateOfCollectionEnd");


### PR DESCRIPTION
Fixes DD-1491 dd-vault-ingest-flow: implement rule CIT025B

# Description of changes
- add new class `DepositDate` to find `dcterms:dateSubmitted` and convert it to `dateOfDeposit` 
   see ['Citation metadata'](https://docs.google.com/spreadsheets/d/1G5YHSDg3a91nI9NgRjbz11iRFU9qgnNkde6K84j1NWI/edit#gid=0&range=95:95) 
   - if not found set date of today
 - `dateOfDeposit` is also defined now in the class `DVCitation` 

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/core-systems
