### PR TITLE
DD-1903 modified JSON-LD serialization to not include @graph

### DIFF
--- a/src/test/java/nl/knaw/dans/vaultingest/core/testutils/TestDepositManager.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/testutils/TestDepositManager.java
@@ -21,7 +21,6 @@ import nl.knaw.dans.vaultingest.core.deposit.DepositManager;
 import nl.knaw.dans.vaultingest.core.xml.XmlReader;
 
 import java.nio.file.Path;
-import java.util.Map;
 
 public class TestDepositManager extends DepositManager {
     private Deposit deposit;
@@ -42,10 +41,6 @@ public class TestDepositManager extends DepositManager {
     private TestDepositManager(Deposit deposit) {
         super(new XmlReader());
         this.deposit = deposit;
-    }
-
-    public static TestDepositManager ofDeposit(Deposit deposit) {
-        return new TestDepositManager(deposit);
     }
 
     @Override


### PR DESCRIPTION
Fixes DD-1903

# Description of changes
Changes `nl.knaw.dans.lib.bagpack.oaiore.OaiOreSerializer#serializeAsJsonLd` to use framing, setting the correct `@type` and using the correct writer + options. 

## Mental health warning
The Jena library is very confusing in that it offers multiple classes with similar names (such as the classes related to the context) but which are not compatible. Also, it tends to silently fail or leave out stuff instead of giving an indication what you are doing wrong.

# Notify
@DANS-KNAW/core-systems
