### PR TITLE
DD-2077 Implement missing mappings.

### DIFF
--- a/src/main/java/nl/knaw/dans/vaultingest/core/baginfo/BagInfoConverter.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/baginfo/BagInfoConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.vaultingest.core.baginfo;
+
+import nl.knaw.dans.vaultingest.config.ContactPersonConfig;
+import nl.knaw.dans.vaultingest.core.deposit.Deposit;
+import nl.knaw.dans.vaultingest.core.deposit.DepositBag;
+import nl.knaw.dans.vaultingest.core.mappings.Descriptions;
+import nl.knaw.dans.vaultingest.core.mappings.Titles;
+
+import java.io.IOException;
+
+public class BagInfoConverter {
+    public static final String KEY_CONTACT_NAME = "Contact-Name";
+    public static final String KEY_CONTACT_EMAIL = "Contact-Email";
+    public static final String KEY_SOURCE_ORGANIZATION = "Source-Organization";
+    public static final String KEY_EXTERNAL_DESCRIPTION = "External-Description";
+    public static final String KEY_EXTERNAL_IDENTIFIER = "External-Identifier";
+    public static final String KEY_INTERNAL_SENDER_IDENTIFIER = "Internal-Sender-Identifier";
+    public static final String KEY_HAS_ORGANIZATIONAL_IDENTIFIER = "Has-Organizational-Identifier";
+
+    public void convert(Deposit deposit, ContactPersonConfig contactPersonConfig, DepositBag depositBag) throws IOException {
+        // BAGINFO001A
+        depositBag.putBagInfoValue(KEY_CONTACT_NAME, contactPersonConfig.getName());
+        depositBag.putBagInfoValue(KEY_CONTACT_EMAIL, contactPersonConfig.getEmail());
+
+        // BAGINFO002A
+        depositBag.putBagInfoValue(KEY_SOURCE_ORGANIZATION, deposit.getDataSupplier());
+
+        // BAGINFO005A
+        try (var s = Descriptions.getAllProfileDescriptions(deposit.getDdm())) {
+            for (var d : s.toList()) {
+                depositBag.putBagInfoValue(KEY_EXTERNAL_DESCRIPTION, d.getValue());
+            }
+        }
+
+        // BAGINFO006A
+        copyHasOrganizationalIdentifierToExternalIdentifier(depositBag);
+
+        // BAGINFO007A
+        depositBag.putBagInfoValue(KEY_INTERNAL_SENDER_IDENTIFIER, Titles.getTitle(deposit.getDdm()));
+    }
+
+    private void copyHasOrganizationalIdentifierToExternalIdentifier(DepositBag depositBag) throws IOException {
+        var hasOrgIds = depositBag.getBagInfoValues(KEY_HAS_ORGANIZATIONAL_IDENTIFIER);
+        var externalDescriptions = depositBag.getBagInfoValues(KEY_EXTERNAL_IDENTIFIER);
+
+        if (hasOrgIds != null) {
+            for (var orgId : hasOrgIds) {
+                if (externalDescriptions == null || !externalDescriptions.contains(orgId)) {
+                    depositBag.putBagInfoValue(KEY_EXTERNAL_IDENTIFIER, orgId);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriter.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriter.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.util.ZipUtil;
 import nl.knaw.dans.vaultingest.config.ContactPersonConfig;
+import nl.knaw.dans.vaultingest.core.baginfo.BagInfoConverter;
 import nl.knaw.dans.vaultingest.core.datacite.DataciteConverter;
 import nl.knaw.dans.vaultingest.core.datacite.DataciteSerializer;
 import nl.knaw.dans.vaultingest.core.deposit.Deposit;
@@ -75,6 +76,9 @@ public class BagPackWriter {
     @NonNull
     private final OaiOreConverter oaiOreConverter;
 
+    @NonNull
+    private final BagInfoConverter bagInfoConverter;
+
     private final Map<Path, Map<SupportedAlgorithm, String>> changedChecksums = new HashMap<>();
     private Set<SupportedAlgorithm> tagManifestAlgorithms;
 
@@ -98,8 +102,8 @@ public class BagPackWriter {
         var pidMappingsSerialized = pidMappingSerializer.serialize(pidMappings);
         checksummedWriteToOutput(Path.of("metadata/pid-mapping.txt"), pidMappingsSerialized);
 
-        deposit.getBag().putBagInfoValue("Contact-Name", contactPersonConfig.getName());
-        deposit.getBag().putBagInfoValue("Contact-Email", contactPersonConfig.getEmail());
+        log.debug("[{}] Adding to bag-info.txt", deposit.getId());
+        bagInfoConverter.convert(deposit, contactPersonConfig, deposit.getBag());
 
         // must be last, because all other files must have been written
         log.debug("[{}] Modifying tagmanifest-*.txt files", deposit.getId());

--- a/src/main/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriterFactory.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriterFactory.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.vaultingest.core.bagpack;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.knaw.dans.vaultingest.config.ContactPersonConfig;
+import nl.knaw.dans.vaultingest.core.baginfo.BagInfoConverter;
 import nl.knaw.dans.vaultingest.core.datacite.DataciteConverter;
 import nl.knaw.dans.vaultingest.core.datacite.DataciteSerializer;
 import nl.knaw.dans.vaultingest.core.deposit.CountryResolver;
@@ -37,6 +38,7 @@ public class BagPackWriterFactory {
     private final DataciteConverter dataciteConverter;
     private final PidMappingConverter pidMappingConverter;
     private final OaiOreConverter oaiOreConverter;
+    private final BagInfoConverter bagInfoConverter;
 
     public BagPackWriterFactory(ContactPersonConfig contactPersonConfig, ObjectMapper objectMapper, LanguageResolver languageResolver, CountryResolver countryResolver) {
         this.contactPersonConfig = contactPersonConfig;
@@ -46,6 +48,7 @@ public class BagPackWriterFactory {
         this.dataciteConverter = new DataciteConverter();
         this.pidMappingConverter = new PidMappingConverter();
         this.oaiOreConverter = new OaiOreConverter(languageResolver, countryResolver);
+        this.bagInfoConverter = new BagInfoConverter();
     }
 
     public BagPackWriter createBagPackWriter(Deposit deposit) {
@@ -57,7 +60,8 @@ public class BagPackWriterFactory {
             oaiOreSerializer,
             dataciteConverter,
             pidMappingConverter,
-            oaiOreConverter
+            oaiOreConverter,
+            bagInfoConverter
         );
     }
 }

--- a/src/main/java/nl/knaw/dans/vaultingest/core/datacite/DataciteConverter.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/datacite/DataciteConverter.java
@@ -47,6 +47,8 @@ public class DataciteConverter {
         resource.setDescriptions(getDescriptions(deposit));
         // DATACITE015
         resource.setPublicationYear(getPublicationYear(deposit));
+        // DATACITE013A
+        resource.setPublisher(getPublisher(deposit));
 
         return resource;
     }
@@ -59,6 +61,12 @@ public class DataciteConverter {
         }
 
         return date.format(yearFormatter);
+    }
+
+    private Resource.Publisher getPublisher(Deposit deposit) {
+        Resource.Publisher publisher = new Resource.Publisher();
+        publisher.setValue(deposit.getDataSupplier());
+        return publisher;
     }
 
     private Resource.Titles getTitles(Deposit deposit) {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/deposit/DepositBag.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/deposit/DepositBag.java
@@ -96,4 +96,8 @@ public class DepositBag {
         MetadataWriter.writeBagMetadata(bag.getMetadata(), Version.LATEST_BAGIT_VERSION(), bag.getRootDir(), StandardCharsets.UTF_8);
 
     }
+
+    public List<String> getBagInfoValues(String key) {
+        return bag.getMetadata().get(key);
+    }
 }

--- a/src/main/java/nl/knaw/dans/vaultingest/core/mappings/Descriptions.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/mappings/Descriptions.java
@@ -81,7 +81,7 @@ public class Descriptions extends Base {
         return result;
     }
 
-    static Stream<Description> getAllProfileDescriptions(Document document) {
+    public static Stream<Description> getAllProfileDescriptions(Document document) {
         return XPathEvaluator.strings(document,
             "/ddm:DDM/ddm:profile/dc:description",
             "/ddm:DDM/ddm:profile/dcterms:description"

--- a/src/main/java/nl/knaw/dans/vaultingest/core/mappings/Titles.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/mappings/Titles.java
@@ -31,7 +31,7 @@ public class Titles {
         return rdfTitle(resource, getTitle(deposit.getDdm()));
     }
 
-    static String getTitle(Document ddm) {
+    public static String getTitle(Document ddm) {
         return XPathEvaluator.strings(ddm, "/ddm:DDM/ddm:profile/dc:title", "ddm:DDM/ddm:profile/dcterms:title")
             .map(String::trim)
             .findFirst()

--- a/src/test/java/nl/knaw/dans/vaultingest/core/baginfo/BagInfoConverterIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/baginfo/BagInfoConverterIntegrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.vaultingest.core.baginfo;
+
+import nl.knaw.dans.vaultingest.config.ContactPersonConfig;
+import nl.knaw.dans.vaultingest.core.deposit.DepositBag;
+import nl.knaw.dans.vaultingest.core.testutils.TestDepositManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BagInfoConverterIntegrationTest {
+
+    @Test
+    void contactName() throws Exception {
+        var depositBag = convertBagInfo();
+
+        assertThat(depositBag.getBagInfoValues(BagInfoConverter.KEY_CONTACT_NAME))
+            .containsOnly("Test Contact Person");
+    }
+
+    @Test
+    void contactEmail() throws Exception {
+        var depositBag = convertBagInfo();
+
+        assertThat(depositBag.getBagInfoValues(BagInfoConverter.KEY_CONTACT_EMAIL))
+            .containsOnly("test@example.com");
+    }
+
+    @Test
+    void sourceOrganization() throws Exception {
+        var depositBag = convertBagInfo();
+
+        assertThat(depositBag.getBagInfoValues(BagInfoConverter.KEY_SOURCE_ORGANIZATION))
+            .containsOnly("Data Supplier");
+    }
+
+    @Test
+    void externalDescription() throws Exception {
+        var depositBag = convertBagInfo();
+
+        var descriptions = depositBag.getBagInfoValues(BagInfoConverter.KEY_EXTERNAL_DESCRIPTION);
+
+        assertThat(descriptions)
+            .isNotNull()
+            .contains("This bags contains one or more examples of each mapping rule.");
+    }
+
+    @Test
+    void internalSenderIdentifier() throws Exception {
+        var depositBag = convertBagInfo();
+
+        assertThat(depositBag.getBagInfoValues(BagInfoConverter.KEY_INTERNAL_SENDER_IDENTIFIER))
+            .containsOnly("A bag containing examples for each mapping rule");
+    }
+
+    @Test
+    void copyHasOrganizationalIdentifierToExternalIdentifier() throws Exception {
+        var depositBag = convertBagInfo();
+
+        var externalIdentifiers = depositBag.getBagInfoValues(BagInfoConverter.KEY_EXTERNAL_IDENTIFIER);
+        var hasOrgIds = depositBag.getBagInfoValues(BagInfoConverter.KEY_HAS_ORGANIZATIONAL_IDENTIFIER);
+
+        if (hasOrgIds != null && !hasOrgIds.isEmpty()) {
+            assertThat(externalIdentifiers)
+                .isNotNull()
+                .containsAll(hasOrgIds);
+        }
+    }
+
+    private DepositBag convertBagInfo() throws Exception {
+        var manager = new TestDepositManager();
+        var deposit = manager.loadDeposit(Path.of("/input/integration-test-complete-bag/c169676f-5315-4d86-bde0-a62dbc915228/"), "Data Supplier");
+
+        var contactPersonConfig = new ContactPersonConfig();
+        contactPersonConfig.setName("Test Contact Person");
+        contactPersonConfig.setEmail("test@example.com");
+
+        var depositBag = deposit.getBag();
+        new BagInfoConverter().convert(deposit, contactPersonConfig, depositBag);
+
+        return depositBag;
+    }
+}

--- a/src/test/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriterTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriterTest.java
@@ -21,6 +21,7 @@ import nl.knaw.dans.bagit.reader.BagReader;
 import nl.knaw.dans.bagit.verify.BagVerifier;
 import nl.knaw.dans.vaultingest.AbstractTestWithTestDir;
 import nl.knaw.dans.vaultingest.config.ContactPersonConfig;
+import nl.knaw.dans.vaultingest.core.baginfo.BagInfoConverter;
 import nl.knaw.dans.vaultingest.core.datacite.DataciteConverter;
 import nl.knaw.dans.vaultingest.core.datacite.DataciteSerializer;
 import nl.knaw.dans.vaultingest.core.deposit.DepositManager;
@@ -64,7 +65,8 @@ class BagPackWriterTest extends AbstractTestWithTestDir {
             new OaiOreSerializer(new ObjectMapper()),
             new DataciteConverter(),
             new PidMappingConverter(),
-            new OaiOreConverter(TestLanguageResolverSingleton.getInstance(), TestCountryResolverSingleton.getInstance())
+            new OaiOreConverter(TestLanguageResolverSingleton.getInstance(), TestCountryResolverSingleton.getInstance()),
+            new BagInfoConverter()
         );
 
         bagPackWriter.writeTo(bagPack);


### PR DESCRIPTION
Fixes DD-2077

# Description of changes
* Refactored code that changes the `bag-infot.txt` file into a separate class `BagInfoConverter` to follow the pattern established for OAI-ORE and DataCite.
* Implemented the new `BAGINFO***` rules.
* Also, implemented `DATACITE013A` to ensure that the datacite.xml validates.

# Notify
@DANS-KNAW/core-systems
