### PR TITLE
DD-2219 and DD-2220 Multi-line/long bag-info.txt value and keeping original bag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <main-class>nl.knaw.dans.vaultingest.DdVaultIngestApplication</main-class>
         <dd-vault-catalog-api.version>1.0.0</dd-vault-catalog-api.version>
+        <dans-bagit-lib.version>1.2.2-SNAPSHOT</dans-bagit-lib.version>
     </properties>
 
     <scm>

--- a/src/main/java/nl/knaw/dans/vaultingest/core/WriteBagPackTask.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/WriteBagPackTask.java
@@ -27,6 +27,7 @@ import nl.knaw.dans.vaultingest.core.deposit.Deposit;
 import nl.knaw.dans.vaultingest.core.deposit.DepositManager;
 import nl.knaw.dans.vaultingest.core.bagpack.BagPackWriterFactory;
 import nl.knaw.dans.vaultingest.core.util.IdMinter;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -72,24 +73,68 @@ public class WriteBagPackTask implements Runnable {
     private UUID depositId;
 
     public void run() {
+        Path originalBagDirBackup = null;
         try {
             log.info("[{}] START processing deposit", getDepositId(depositDir));
-            var bagDir = getBagDir(depositDir);
+            var originalBagDir = getBagDir(depositDir);
 
-            bagValidator.validate(getDepositId(depositDir), bagDir);
+            if (originalBagDir == null) {
+                throw new InvalidDepositException("No bag directory found in deposit");
+            }
+
+            originalBagDirBackup = depositDir.resolve("org-" + originalBagDir.getFileName());
+            if (Files.exists(originalBagDirBackup)) {
+                FileUtils.deleteDirectory(originalBagDirBackup.toFile());
+            }
+            FileUtils.copyDirectory(originalBagDir.toFile(), originalBagDirBackup.toFile());
+            log.debug("[{}] Created backup of original bag at: {}", getDepositId(depositDir), originalBagDirBackup);
+
+            bagValidator.validate(getDepositId(depositDir), originalBagDir);
 
             log.debug("[{}] Loading deposit info", getDepositId(depositDir));
             deposit = depositManager.loadDeposit(depositDir, dataSupplier);
+
             processDeposit();
+
+            if (Files.exists(originalBagDir)) {
+                FileUtils.deleteDirectory(originalBagDir.toFile());
+            }
+            Files.move(originalBagDirBackup, originalBagDir);
+            originalBagDirBackup = null;
 
             depositManager.saveDepositProperties(deposit);
             log.debug("[{}] Saved deposit properties", getDepositId(depositDir));
             depositManager.updateDepositState(depositDir, Deposit.State.ACCEPTED, "Deposit accepted");
-            Files.move(depositDir, outboxProcessed.resolve(depositDir.getFileName()));
-            log.info("[{}] Moved deposit to outbox", getDepositId(depositDir));
+            var target = outboxProcessed.resolve(depositDir.getFileName());
+            log.info("[{}] Moving original deposit {} to {}", getDepositId(depositDir), depositDir, target);
+            if (Files.exists(target)) {
+                FileUtils.deleteQuietly(target.toFile());
+            }
+            try {
+                Files.move(depositDir, target);
+            }
+            catch (IOException e) {
+                log.error("[{}] Failed to move deposit directory {} to {}. Falling back to copy and delete.", getDepositId(depositDir), depositDir, target, e);
+                FileUtils.copyDirectory(depositDir.toFile(), target.toFile());
+                FileUtils.deleteDirectory(depositDir.toFile());
+            }
+            log.info("[{}] Moved original deposit to outbox", getDepositId(depositDir));
         }
         catch (InvalidDepositException e) {
             log.warn("[{}] REJECTED deposit: {}", getDepositId(depositDir), e.getMessage());
+            if (originalBagDirBackup != null && Files.exists(originalBagDirBackup)) {
+                try {
+                    // Re-calculate or use the one from before
+                    var originalBagDir = depositDir.resolve(originalBagDirBackup.getFileName().toString().substring(4));
+                    if (Files.exists(originalBagDir)) {
+                        FileUtils.deleteDirectory(originalBagDir.toFile());
+                    }
+                    Files.move(originalBagDirBackup, originalBagDir);
+                }
+                catch (IOException ioException) {
+                    log.error("[{}] Failed to restore original bag from backup", getDepositId(depositDir), ioException);
+                }
+            }
             try {
                 depositManager.updateDepositState(depositDir, Deposit.State.REJECTED, e.getMessage());
                 Files.move(depositDir, outboxRejected.resolve(depositDir.getFileName()));
@@ -100,6 +145,19 @@ public class WriteBagPackTask implements Runnable {
         }
         catch (Exception e) {
             log.error("[{}] FAILED deposit: {}", getDepositId(depositDir), e.getMessage(), e);
+            if (originalBagDirBackup != null && Files.exists(originalBagDirBackup)) {
+                try {
+                    // Re-calculate or use the one from before
+                    var originalBagDir = depositDir.resolve(originalBagDirBackup.getFileName().toString().substring(4));
+                    if (Files.exists(originalBagDir)) {
+                        FileUtils.deleteDirectory(originalBagDir.toFile());
+                    }
+                    Files.move(originalBagDirBackup, originalBagDir);
+                }
+                catch (IOException ioException) {
+                    log.error("[{}] Failed to restore original bag from backup", getDepositId(depositDir), ioException);
+                }
+            }
             try {
                 depositManager.updateDepositState(depositDir, Deposit.State.FAILED, e.getMessage());
                 Files.move(depositDir, outboxFailed.resolve(depositDir.getFileName()));
@@ -108,8 +166,20 @@ public class WriteBagPackTask implements Runnable {
                 log.error("[{}] Failed to handle failed deposit", getDepositId(depositDir), ioException);
             }
         }
+        finally {
+            if (originalBagDirBackup != null) {
+                try {
+                    FileUtils.deleteDirectory(originalBagDirBackup.toFile());
+                    log.debug("[{}] Cleaned up backup directory: {}", getDepositId(depositDir), originalBagDirBackup);
+                }
+                catch (IOException e) {
+                    log.error("[{}] Failed to clean up backup directory: {}", getDepositId(depositDir), originalBagDirBackup, e);
+                }
+            }
+        }
         log.info("[{}] END processing deposit", getDepositId(depositDir));
     }
+
 
     private UUID getDepositId(Path path) {
         if (depositId == null) {

--- a/src/main/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriter.java
+++ b/src/main/java/nl/knaw/dans/vaultingest/core/bagpack/BagPackWriter.java
@@ -112,6 +112,7 @@ public class BagPackWriter {
         log.debug("[{}] Zipping directory {} to {}", deposit.getId(), deposit.getBagDir(), tempZipFile);
         ZipUtil.zipDirectory(deposit.getBagDir(), tempZipFile, true);
         log.debug("[{}] Moving {} to {}", deposit.getId(), tempZipFile, bagPack);
+        Files.deleteIfExists(bagPack);
         Files.move(tempZipFile, bagPack);
     }
 

--- a/src/test/java/nl/knaw/dans/vaultingest/core/WriteBagPackTaskTest.java
+++ b/src/test/java/nl/knaw/dans/vaultingest/core/WriteBagPackTaskTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.vaultingest.core;
+
+import nl.knaw.dans.vaultcatalog.api.DatasetDto;
+import nl.knaw.dans.vaultingest.AbstractTestWithTestDir;
+import nl.knaw.dans.vaultingest.client.BagValidator;
+import nl.knaw.dans.vaultingest.client.VaultCatalogClient;
+import nl.knaw.dans.vaultingest.core.bagpack.BagPackWriter;
+import nl.knaw.dans.vaultingest.core.bagpack.BagPackWriterFactory;
+import nl.knaw.dans.vaultingest.core.deposit.Deposit;
+import nl.knaw.dans.vaultingest.core.deposit.DepositManager;
+import nl.knaw.dans.vaultingest.core.util.IdMinter;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+class WriteBagPackTaskTest extends AbstractTestWithTestDir {
+
+    private final Path outboxProcessed = testDir.resolve("outbox/processed");
+    private final Path outboxFailed = testDir.resolve("outbox/failed");
+    private final Path outboxRejected = testDir.resolve("outbox/rejected");
+    private final Path dveOutbox = testDir.resolve("dve-outbox");
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Files.createDirectories(outboxProcessed);
+        Files.createDirectories(outboxFailed);
+        Files.createDirectories(outboxRejected);
+        Files.createDirectories(dveOutbox);
+    }
+
+    @Test
+    void run_should_backup_bag_and_use_original_for_processing_on_success() throws Exception {
+        var depositId = UUID.randomUUID();
+        var depositDir = testDir.resolve(depositId.toString());
+        var bagDir = depositDir.resolve("my-bag");
+        Files.createDirectories(bagDir.resolve("data"));
+        Files.writeString(bagDir.resolve("bagit.txt"), "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n");
+        Files.writeString(bagDir.resolve("manifest-sha1.txt"), "");
+        Files.writeString(depositDir.resolve("deposit.properties"), "creation.timestamp=2023-01-01T00:00:00Z\ndataverse.bag-id=" + depositId);
+
+        var bagValidator = Mockito.mock(BagValidator.class);
+        var vaultCatalogClient = Mockito.mock(VaultCatalogClient.class);
+        var idMinter = Mockito.mock(IdMinter.class);
+        var depositManager = Mockito.mock(DepositManager.class);
+        var rdaBagWriterFactory = Mockito.mock(BagPackWriterFactory.class);
+        var bagPackWriter = Mockito.mock(BagPackWriter.class);
+
+        var deposit = Mockito.mock(Deposit.class);
+        Mockito.when(deposit.getId()).thenReturn(depositId.toString());
+        Mockito.when(deposit.getBagId()).thenReturn(depositId.toString());
+        Mockito.when(deposit.getObjectVersion()).thenReturn(1);
+        Mockito.when(deposit.isUpdate()).thenReturn(false);
+        Mockito.when(deposit.getBagDir()).thenReturn(bagDir);
+        var properties = Mockito.mock(nl.knaw.dans.vaultingest.core.deposit.DepositProperties.class);
+        Mockito.when(deposit.getProperties()).thenReturn(properties);
+        Mockito.when(properties.getBagId()).thenReturn(depositId.toString());
+
+        Mockito.when(depositManager.loadDeposit(any(), anyString())).thenReturn(deposit);
+        Mockito.when(rdaBagWriterFactory.createBagPackWriter(any())).thenReturn(bagPackWriter);
+        Mockito.when(idMinter.mintUrnNbn()).thenReturn("urn:nbn:nl:ui:13-test");
+
+        // Need to mock dataset for createSkeletonRecordInVaultCatalog
+        var dataset = Mockito.mock(DatasetDto.class);
+        Mockito.when(vaultCatalogClient.findDataset(anyString())).thenReturn(java.util.Optional.of(dataset));
+
+        var task = new WriteBagPackTask(
+            depositDir,
+            outboxProcessed,
+            outboxFailed,
+            outboxRejected,
+            "root",
+            "user",
+            rdaBagWriterFactory,
+            vaultCatalogClient,
+            bagValidator,
+            idMinter,
+            depositManager,
+            dveOutbox
+        );
+
+        task.run();
+
+        // Verify original depositDir (containing everything) was moved to outboxProcessed
+        var movedDepositDir = outboxProcessed.resolve(depositId.toString());
+        assertThat(movedDepositDir).exists();
+        assertThat(depositDir).doesNotExist();
+
+        // Verify that the backup bag (org-) was cleaned up from the moved directory
+        assertThat(movedDepositDir.resolve("org-my-bag")).doesNotExist();
+        assertThat(movedDepositDir.resolve("my-bag")).exists();
+
+        // Verify that bagValidator was called with the original bag path
+        Mockito.verify(bagValidator).validate(eq(depositId), eq(bagDir));
+
+        // Verify BagPackWriter was called
+        Mockito.verify(bagPackWriter).writeTo(any());
+    }
+
+    @Test
+    void run_should_move_to_rejected_on_InvalidDepositException() throws Exception {
+        var depositId = UUID.randomUUID();
+        var depositDir = testDir.resolve(depositId.toString());
+        Files.createDirectories(depositDir);
+
+        var bagValidator = Mockito.mock(BagValidator.class);
+        Mockito.doThrow(new nl.knaw.dans.vaultingest.client.InvalidDepositException("Invalid"))
+            .when(bagValidator).validate(any(), any());
+
+        var task = new WriteBagPackTask(
+            depositDir,
+            outboxProcessed,
+            outboxFailed,
+            outboxRejected,
+            "root",
+            "user",
+            Mockito.mock(BagPackWriterFactory.class),
+            Mockito.mock(VaultCatalogClient.class),
+            bagValidator,
+            Mockito.mock(IdMinter.class),
+            Mockito.mock(DepositManager.class),
+            dveOutbox
+        );
+
+        task.run();
+
+        assertThat(outboxRejected.resolve(depositId.toString())).exists();
+        assertThat(depositDir).doesNotExist();
+    }
+}


### PR DESCRIPTION
Fixes DD-2219 and DD-2220

# Description of changes
* Upgrades to the next version of `dans-bagit-lib` which resolves issues with creating multi-line or longer values in `bag-info.txt`. See https://github.com/DANS-KNAW/dans-bagit-lib/pull/12 (DD-2219)
* Changes processing by first creating a copy of the original bag and then transforming it, so that, if things fail, a retry is easier to perform. 

# Related PRs
* https://github.com/DANS-KNAW/dans-bagit-lib/pull/12

# Notify
@DANS-KNAW/core-systems
